### PR TITLE
Run Servo with CPU rendering

### DIFF
--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -25,7 +25,7 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
         self.result_data = None
         self.result_flag = threading.Event()
 
-        self.command = [self.binary, "--hard-fail",
+        self.command = [self.binary, "--cpu", "--hard-fail",
                         urlparse.urljoin(self.http_server_url, test.url)]
 
         if self.debug_args:


### PR DESCRIPTION
This disables Servo's GPU rendering path.  Running with CPU rendering allows Servo to run on a wider range of platforms, including headless servers.  This is how we (the Servo team) run Servo's own automated tests on Linux.
