### PR TITLE
Create tempdir for metadata changes in same parent dir

### DIFF
--- a/wptrunner/metadata.py
+++ b/wptrunner/metadata.py
@@ -142,7 +142,7 @@ def update_from_logs(metadata_path, manifest, *log_filenames, **kwargs):
 
 def write_changes(metadata_path, expected_map):
     # First write the new manifest files to a temporary directory
-    temp_path = tempfile.mkdtemp()
+    temp_path = tempfile.mkdtemp(dir=os.path.split(metadata_path)[0])
     write_new_expected(temp_path, expected_map)
     shutil.copyfile(os.path.join(metadata_path, "MANIFEST.json"),
                     os.path.join(temp_path, "MANIFEST.json"))


### PR DESCRIPTION
so that it will usually be on the same filesystem.

tempfile.mkdtemp() is still making the new directory with permissions
that will likely differ from the old directory.
