### PR TITLE
Fix broken --list-disabled option

### DIFF
--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -523,6 +523,8 @@ def list_test_groups(tests_root, metadata_root, test_types, product, **kwargs):
 
 
 def list_disabled(tests_root, metadata_root, test_types, product, **kwargs):
+    do_test_relative_imports(tests_root)
+
     rv = []
     run_info = wpttest.get_run_info(metadata_root, product, debug=False)
     test_loader = TestLoader(tests_root, metadata_root, TestFilter(), run_info)


### PR DESCRIPTION
Invoking wptrunner with the --list-disabled throws an execption
 `NameError: global name 'manifest' is not defined`

Stack trace:

```
Traceback (most recent call last):
  File "~/Dev/wptrunner/bin/wptrunner", line 9, in <module>
    load_entry_point('wptrunner==1.4', 'console_scripts', 'wptrunner')()
  File "~/Dev/wptrunner/wptrunner/wptrunner/wptrunner.py", line 657, in main
    list_disabled(**kwargs)
  File "~/Dev/wptrunner/wptrunner/wptrunner/wptrunner.py", line 528, in list_disabled
    test_loader = TestLoader(tests_root, metadata_root, TestFilter(), run_info)
  File "~/Dev/wptrunner/wptrunner/wptrunner/wptrunner.py", line 378, in __init__
    self.manifest = self.load_manifest()
  File "~/Dev/wptrunner/wptrunner/wptrunner/wptrunner.py", line 391, in load_manifest
    return manifest.load(self.manifest_path)
NameError: global name 'manifest' is not defined
```
