### PR TITLE
Fixed regression in config-file reading.

### DIFF
--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -138,6 +138,8 @@ def set_from_config(kwargs):
     kwargs["test_paths"] = OrderedDict()
 
     keys = {"paths": [("serve", "serve_root", True),
+                      ("tests", "tests_root", True),
+                      ("metadata", "metadata_root", True),
                       ("prefs", "prefs_root", True),
                       ("run_info", "run_info", True)],
             "web-platform-tests": [("remote_url", "remote_url", False),


### PR DESCRIPTION
This change causes the `wptcommandline.py` code to once again read
the `tests` and `metadata` paths from the `[paths]` section of the
`wptrunner.default.ini` config file or other specified config file.

(In https://github.com/w3c/wptrunner/commit/815882453fec3191d95bfe9777367829151398b8 -- specifically in https://github.com/w3c/wptrunner/commit/815882453fec3191d95bfe9777367829151398b8#diff-409148835eecbf686495abf6ffd37cb5L125
a change was made that regressed config-file reading in such a way as to
cause the code to just ignore any `tests` and `metadata` paths specified in
the `[paths]` section of the `wptrunner.default.ini` config file or other
specified config file.)