### PR TITLE
Add a finish handler to the Servo executor.

### DIFF
--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -33,7 +33,8 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
 
 
         self.proc = ProcessHandler(self.command,
-                                   processOutputLine=[self.on_output])
+                                   processOutputLine=[self.on_output],
+                                   onFinish=self.on_finish)
         self.proc.run()
 
         timeout = test.timeout * self.timeout_multiplier
@@ -67,3 +68,6 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
                 self.logger.process_output(self.proc.pid,
                                            line,
                                            " ".join(self.command))
+
+    def on_finish(self):
+        self.result_flag.set()


### PR DESCRIPTION
This avoids an unnecessary delay in case the browser crashes or exits before
the result is printed.
