### PR TITLE
Test for self.result_data in ServoTestharnessExecutor.

### DIFF
--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -42,8 +42,7 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
         # Now wait to get the output we expect, or until we reach the timeout
         self.result_flag.wait(timeout + 5)
 
-        if self.result_flag.is_set():
-            assert self.result_data is not None
+        if self.result_flag.is_set() and self.result_data is not None:
             self.result_data["test"] = test.url
             result = self.convert_result(test, self.result_data)
             self.proc.kill()


### PR DESCRIPTION
This fixes a bug introduced by 291fa69beeda50a8c5b790c7a48bf9ebbfd81653 that
made crashes fail the removed assertion.
