### PR TITLE
Return whether unexpected_total is zero in run_tests.

### DIFF
--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -482,7 +482,7 @@ def run_tests(config, serve_root, test_paths, product, **kwargs):
                 logging_thread.join(10)
             logging_queue.close()
 
-    return manager_group.unexpected_count() == 0
+    return unexpected_total == 0
 
 
 def main():


### PR DESCRIPTION
In the case of running tests in a loop, we calculate the total number of
failures, but only return whether the last run failed.