### PR TITLE
Changes to work better in a debugger.

### DIFF
--- a/wptrunner/executors/base.py
+++ b/wptrunner/executors/base.py
@@ -15,7 +15,8 @@ def executor_kwargs(http_server_url, **kwargs):
         timeout_multiplier = 1
 
     executor_kwargs = {"http_server_url": http_server_url,
-                       "timeout_multiplier": timeout_multiplier}
+                       "timeout_multiplier": timeout_multiplier,
+                       "debug_args": kwargs["debug_args"]}
     return executor_kwargs
 
 
@@ -49,7 +50,8 @@ class TestExecutor(object):
 
     convert_result = None
 
-    def __init__(self, browser, http_server_url, timeout_multiplier=1):
+    def __init__(self, browser, http_server_url, timeout_multiplier=1,
+                 debug_args=None):
         """Abstract Base class for object that actually executes the tests in a
         specific browser. Typically there will be a different TestExecutor
         subclass for each test type and method of executing tests.
@@ -65,6 +67,7 @@ class TestExecutor(object):
         self.browser = browser
         self.http_server_url = http_server_url
         self.timeout_multiplier = timeout_multiplier
+        self.debug_args = debug_args
 
     @property
     def logger(self):

--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -38,7 +38,7 @@ class MarionetteTestExecutor(TestExecutor):
                  browser,
                  http_server_url,
                  timeout_multiplier=1,
-                 debug_args={},
+                 debug_args=None,
                  close_after_done=True):
         do_delayed_imports()
 

--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -38,10 +38,11 @@ class MarionetteTestExecutor(TestExecutor):
                  browser,
                  http_server_url,
                  timeout_multiplier=1,
+                 debug_args={},
                  close_after_done=True):
         do_delayed_imports()
 
-        TestExecutor.__init__(self, browser, http_server_url, timeout_multiplier)
+        TestExecutor.__init__(self, browser, http_server_url, timeout_multiplier, debug_args)
         self.marionette_port = browser.marionette_port
         self.marionette = None
 
@@ -57,7 +58,12 @@ class MarionetteTestExecutor(TestExecutor):
         self.marionette = marionette.Marionette(host='localhost', port=self.marionette_port)
         # XXX Move this timeout somewhere
         self.logger.debug("Waiting for Marionette connection")
-        success = self.marionette.wait_for_port(60)
+        while True:
+            success = self.marionette.wait_for_port(60)
+            #When running in a debugger wait indefinitely for firefox to start
+            if success or self.debug_args is None:
+                break
+
         session_started = False
         if success:
             try:
@@ -138,8 +144,9 @@ class MarionetteTestExecutor(TestExecutor):
                     result = (test.result_cls("EXTERNAL-TIMEOUT", None), [])
                     self.runner.send_message("test_ended", test, result)
 
-        self.timer = threading.Timer(timeout + 2 * extra_timeout, timeout_func)
-        self.timer.start()
+        if self.debug_args is None:
+            self.timer = threading.Timer(timeout + 2 * extra_timeout, timeout_func)
+            self.timer.start()
 
         try:
             self.marionette.set_script_timeout((timeout + extra_timeout) * 1000)
@@ -178,7 +185,8 @@ class MarionetteTestExecutor(TestExecutor):
                     result_flag.set()
                     result = (test.result_cls("CRASH", None), [])
         finally:
-            self.timer.cancel()
+            if self.timer is not None:
+                self.timer.cancel()
 
         with result_lock:
             if result:
@@ -209,7 +217,8 @@ class MarionetteTestharnessExecutor(MarionetteTestExecutor):
                            "url": test.url,
                            "window_id": self.window_id,
                            "timeout_multiplier": self.timeout_multiplier,
-                           "timeout": timeout * 1000}, new_sandbox=False)
+                           "timeout": timeout * 1000,
+                           "explicit_timeout": self.debug_args is not None}, new_sandbox=False)
 
 
 class MarionetteReftestExecutor(MarionetteTestExecutor):

--- a/wptrunner/executors/executorselenium.py
+++ b/wptrunner/executors/executorselenium.py
@@ -33,9 +33,9 @@ def do_delayed_imports():
 
 class SeleniumTestExecutor(TestExecutor):
     def __init__(self, browser, http_server_url, capabilities,
-                 timeout_multiplier=1, **kwargs):
+                 timeout_multiplier=1, debug_args=None, **kwargs):
         do_delayed_imports()
-        TestExecutor.__init__(self, browser, http_server_url, timeout_multiplier)
+        TestExecutor.__init__(self, browser, http_server_url, timeout_multiplier, debug_args)
         self.capabilities = capabilities
         self.url = browser.webdriver_url
         self.webdriver = None

--- a/wptrunner/executors/process.py
+++ b/wptrunner/executors/process.py
@@ -9,7 +9,6 @@ class ProcessTestExecutor(TestExecutor):
     def __init__(self, *args, **kwargs):
         TestExecutor.__init__(self, *args, **kwargs)
         self.binary = self.browser.binary
-        self.debug_args = self.browser.debug_args
         self.interactive = self.browser.interactive
 
     def setup(self, runner):

--- a/wptrunner/executors/testharness_marionette.js
+++ b/wptrunner/executors/testharness_marionette.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 window.wrappedJSObject.timeout_multiplier = %(timeout_multiplier)d;
+window.wrappedJSObject.explicit_timeout = %(explicit_timeout)d;
 
 window.wrappedJSObject.done = function(tests, status) {
   clearTimeout(timer);

--- a/wptrunner/testharnessreport.js
+++ b/wptrunner/testharnessreport.js
@@ -7,6 +7,9 @@ var props = {output:false,
 if (window.opener && "timeout_multiplier" in window.opener) {
     props["timeout_multiplier"] = window.opener.timeout_multiplier;
 }
+if (window.opener && window.opener.explicit_timeout) {
+    props["explicit_timeout"] = window.opener.explicit_timeout;
+}
 setup(props);
 add_completion_callback(function() {
     add_completion_callback(function(tests, status) {

--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -454,7 +454,8 @@ def run_tests(config, serve_root, test_paths, product, **kwargs):
                                       browser_kwargs,
                                       executor_cls,
                                       executor_kwargs,
-                                      kwargs["pause_on_unexpected"]) as manager_group:
+                                      kwargs["pause_on_unexpected"],
+                                      kwargs["debug_args"]) as manager_group:
                         try:
                             manager_group.run(test_type, test_loader.tests)
                         except KeyboardInterrupt:


### PR DESCRIPTION
Don't time out when waiting to connect to the Firefox process. Disable test timeout
when the debugger is active.