### PR TITLE
Make the cache manager owned by the TestEnvironment so it can be shut down correctly.

### DIFF
--- a/wptrunner/browsers/b2g.py
+++ b/wptrunner/browsers/b2g.py
@@ -46,12 +46,13 @@ def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
     if timeout_multiplier is None:
         timeout_multiplier = 2
 
-    if test_type == "reftest":
-        executor_kwargs["cache_manager"] = cache_manager
-
     executor_kwargs = {"http_server_url": http_server_url,
                        "timeout_multiplier": timeout_multiplier,
                        "close_after_done": False}
+
+    if test_type == "reftest":
+        executor_kwargs["cache_manager"] = cache_manager
+
     return executor_kwargs
 
 

--- a/wptrunner/browsers/b2g.py
+++ b/wptrunner/browsers/b2g.py
@@ -41,10 +41,13 @@ def browser_kwargs(test_environment, **kwargs):
             "no_backup": kwargs.get("b2g_no_backup", False)}
 
 
-def executor_kwargs(test_type, http_server_url, **kwargs):
+def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
     timeout_multiplier = kwargs["timeout_multiplier"]
     if timeout_multiplier is None:
         timeout_multiplier = 2
+
+    if test_type == "reftest":
+        executor_kwargs["cache_manager"] = cache_manager
 
     executor_kwargs = {"http_server_url": http_server_url,
                        "timeout_multiplier": timeout_multiplier,

--- a/wptrunner/browsers/chrome.py
+++ b/wptrunner/browsers/chrome.py
@@ -28,10 +28,11 @@ def browser_kwargs(**kwargs):
             "webdriver_binary": kwargs["webdriver_binary"]}
 
 
-def executor_kwargs(test_type, http_server_url, **kwargs):
+def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
     from selenium.webdriver import DesiredCapabilities
 
-    executor_kwargs = base_executor_kwargs(test_type, http_server_url, **kwargs)
+    executor_kwargs = base_executor_kwargs(test_type, http_server_url,
+                                           cache_manager, **kwargs)
     executor_kwargs["close_after_done"] = True
     executor_kwargs["capabilities"] = dict(DesiredCapabilities.CHROME.items() +
                                            {"chromeOptions":

--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -45,8 +45,9 @@ def browser_kwargs(**kwargs):
             "ca_certificate_path": kwargs["ssl_env"].ca_cert_path()}
 
 
-def executor_kwargs(test_type, http_server_url, **kwargs):
-    executor_kwargs = base_executor_kwargs(test_type, http_server_url, **kwargs)
+def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, http_server_url,
+                                           cache_manager, **kwargs)
     executor_kwargs["close_after_done"] = True
     return executor_kwargs
 

--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -30,8 +30,9 @@ def browser_kwargs(**kwargs):
             "interactive": kwargs["interactive"]}
 
 
-def executor_kwargs(test_type, http_server_url, **kwargs):
-    rv = base_executor_kwargs(test_type, http_server_url, **kwargs)
+def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
+    rv = base_executor_kwargs(test_type, http_server_url,
+                              cache_manager, **kwargs)
     rv["pause_after_test"] = kwargs["pause_after_test"]
     return rv
 

--- a/wptrunner/environment.py
+++ b/wptrunner/environment.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import multiprocessing
 import socket
 import sys
 import time
@@ -97,8 +98,11 @@ class TestEnvironment(object):
         self.test_server_port = options.pop("test_server_port", True)
         self.options = options if options is not None else {}
 
+        self.cache_manager = multiprocessing.Manager()
+
     def __enter__(self):
         self.ssl_env.__enter__()
+        self.cache_manager.__enter__()
         self.setup_server_logging()
         self.setup_routes()
         self.config = self.load_config()
@@ -107,6 +111,7 @@ class TestEnvironment(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cache_manager.__exit__(exc_type, exc_val, exc_tb)
         self.ssl_env.__exit__(exc_type, exc_val, exc_tb)
 
         for scheme, servers in self.servers.iteritems():

--- a/wptrunner/executors/base.py
+++ b/wptrunner/executors/base.py
@@ -7,7 +7,6 @@ import json
 import os
 import traceback
 from abc import ABCMeta, abstractmethod
-from multiprocessing import Manager
 
 from ..testrunner import Stop
 

--- a/wptrunner/executors/base.py
+++ b/wptrunner/executors/base.py
@@ -13,9 +13,8 @@ from ..testrunner import Stop
 
 here = os.path.split(__file__)[0]
 
-cache_manager = Manager()
 
-def executor_kwargs(test_type, http_server_url, **kwargs):
+def executor_kwargs(test_type, http_server_url, cache_manager, **kwargs):
     timeout_multiplier = kwargs["timeout_multiplier"]
     if timeout_multiplier is None:
         timeout_multiplier = 1

--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -158,6 +158,7 @@ def run_tests(config, test_paths, product, **kwargs):
                     executor_cls = executor_classes.get(test_type)
                     executor_kwargs = get_executor_kwargs(test_type,
                                                           base_server,
+                                                          test_environment.cache_manager,
                                                           **kwargs)
 
                     if executor_cls is None:


### PR DESCRIPTION
This should fix a hang on Windows 8