### PR TITLE
Use prefs to set up local dns entries for firefox rather than autoproxy.

### DIFF
--- a/wptrunner/browsers/b2g.py
+++ b/wptrunner/browsers/b2g.py
@@ -20,6 +20,7 @@ from mozprofile import FirefoxProfile, Preferences
 from .base import get_free_port, BrowserError, Browser, ExecutorBrowser
 from ..executors.executormarionette import MarionetteTestharnessExecutor
 from ..hosts import HostsFile, HostsLine
+from ..environment import hostnames
 
 here = os.path.split(__file__)[0]
 
@@ -115,13 +116,6 @@ class B2GBrowser(Browser):
         self.logger.debug("Device runner started")
 
     def setup_hosts(self):
-        hostnames = ["web-platform.test",
-                     "www.web-platform.test",
-                     "www1.web-platform.test",
-                     "www2.web-platform.test",
-                     "xn--n8j6ds53lwwkrqhv28a.web-platform.test",
-                     "xn--lve-6lad.web-platform.test"]
-
         host_ip = moznetwork.get_ip()
 
         temp_dir = tempfile.mkdtemp()

--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -53,7 +53,8 @@ def executor_kwargs(test_type, server_config, cache_manager, **kwargs):
 
 
 def env_options():
-    return {"host": "web-platform.test",
+    return {"host": "127.0.0.1",
+            "external_host": "web-platform.test",
             "bind_hostname": "false",
             "certificate_domain": "web-platform.test",
             "encrypt_after_connect": True,
@@ -88,10 +89,6 @@ class FirefoxBrowser(Browser):
         locations = ServerLocations(filename=os.path.join(here, "server-locations.txt"))
 
         preferences = self.load_prefs()
-
-        ports = {"http": "8000",
-                 "https": "8443",
-                 "ws": "8888"}
 
         self.profile = FirefoxProfile(locations=locations,
                                       preferences=preferences)

--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -15,6 +15,7 @@ from mozcrash import mozcrash
 from .base import get_free_port, Browser, ExecutorBrowser, require_arg, cmd_arg, browser_command
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executormarionette import MarionetteTestharnessExecutor, MarionetteRefTestExecutor
+from ..environment import hostnames
 
 here = os.path.join(os.path.split(__file__)[0])
 
@@ -52,8 +53,7 @@ def executor_kwargs(test_type, server_config, cache_manager, **kwargs):
 
 
 def env_options():
-    return {"host": "127.0.0.1",
-            "external_host": "web-platform.test",
+    return {"host": "web-platform.test",
             "bind_hostname": "false",
             "certificate_domain": "web-platform.test",
             "encrypt_after_connect": True,
@@ -94,11 +94,11 @@ class FirefoxBrowser(Browser):
                  "ws": "8888"}
 
         self.profile = FirefoxProfile(locations=locations,
-                                      proxy=ports,
                                       preferences=preferences)
         self.profile.set_preferences({"marionette.defaultPrefs.enabled": True,
                                       "marionette.defaultPrefs.port": self.marionette_port,
-                                      "dom.disable_open_during_load": False})
+                                      "dom.disable_open_during_load": False,
+                                      "network.dns.localDomains": ",".join(hostnames)})
 
         if self.ca_certificate_path is not None:
             self.setup_ssl()

--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -57,7 +57,6 @@ def env_options():
             "external_host": "web-platform.test",
             "bind_hostname": "false",
             "certificate_domain": "web-platform.test",
-            "encrypt_after_connect": True,
             "supports_debugger": True}
 
 

--- a/wptrunner/environment.py
+++ b/wptrunner/environment.py
@@ -19,6 +19,15 @@ here = os.path.split(__file__)[0]
 serve = None
 sslutils = None
 
+
+hostnames = ["web-platform.test",
+             "www.web-platform.test",
+             "www1.web-platform.test",
+             "www2.web-platform.test",
+             "xn--n8j6ds53lwwkrqhv28a.web-platform.test",
+             "xn--lve-6lad.web-platform.test"]
+
+
 def do_delayed_imports(logger, test_paths):
     global serve, sslutils
 


### PR DESCRIPTION
This is substantially less complex since servers don't have to deal with CONNECT
requests, and paves the way for enabling wss.