### PR TITLE
Fix combination of --include and --exclude.

### DIFF
--- a/wptrunner/manifestinclude.py
+++ b/wptrunner/manifestinclude.py
@@ -57,7 +57,7 @@ class IncludeManifest(ManifestItem):
             try:
                 skip_value = self.get("skip", {"test_type": test.item_type}).lower()
                 assert skip_value in ("true", "false")
-                return False if skip_value == "true" else True
+                return skip_value != "true"
             except KeyError:
                 if node.parent is not None:
                     node = node.parent
@@ -107,6 +107,7 @@ class IncludeManifest(ManifestItem):
             if component not in node.child_map:
                 new_node = IncludeManifest(DataNode(component))
                 node.append(new_node)
+                new_node.set("skip", node.get("skip", {}))
 
             node = node.child_map[component]
 


### PR DESCRIPTION
Manifests have the semantic of either looking at the value from
the current key, or the value from the root (not the value from
the parent). This is necessary for expected keys to work well,
but isn't really what's needed for include manifests. In particular
the --include and --exclude functions were acting as if we would
traverse up the parent node chain of the manifest until we found
an explicitly set skip key. Instead we make sure that skip is
set on every node in the chain.