### PR TITLE
Remove unnecessary postMessage from testharness report.

### DIFF
--- a/wptrunner/testharnessreport.js
+++ b/wptrunner/testharnessreport.js
@@ -15,16 +15,3 @@ if (window.opener && window.opener.explicit_timeout) {
 }
 
 setup(props);
-add_completion_callback(function() {
-    add_completion_callback(function(tests, status) {
-        var harness_status = {
-            "status": status.status,
-            "message": status.message,
-            "stack": status.stack
-        };
-        var test_results = tests.map(function(x) {
-            return {name:x.name, status:x.status, message:x.message, stack:x.stack}
-        });
-        window.opener.postMessage([test_results, harness_status], "*");
-    })
-});


### PR DESCRIPTION
testharness.js does this already; no need to repeat it here