### PR TITLE
Disable debug-level logging for marionette component when running in Firefox.

### DIFF
--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -107,6 +107,12 @@ class MarionetteProtocol(Protocol):
         return True
 
     def after_connect(self):
+        # Turn off debug-level logging by default since this is so verbose
+        with self.marionette.using_context("chrome"):
+            self.marionette.execute_script("""
+              Components.utils.import("resource://gre/modules/Log.jsm");
+              Log.repository.getLogger("Marionette").level = Log.Level.Info;
+            """)
         self.load_runner("http")
 
     def load_runner(self, protocol):


### PR DESCRIPTION
This is harmful because it can end up generating a whole lot of unnecessary
log data from the result messages.