### PR TITLE
Ensure that routes for url bases other than / are inserted before the python handler for /

### DIFF
--- a/wptrunner/environment.py
+++ b/wptrunner/environment.py
@@ -80,25 +80,6 @@ class TestEnvironmentError(Exception):
     pass
 
 
-class StaticHandler(object):
-    def __init__(self, path, format_args, content_type, **headers):
-        with open(path) as f:
-            self.data = f.read() % format_args
-
-        self.resp_headers = [("Content-Type", content_type)]
-        for k, v in headers.iteritems():
-            resp_headers.append((k.replace("_", "-"), v))
-
-        self.handler = serve.handlers.handler(self.handle_request)
-
-    def handle_request(self, request, response):
-        return self.resp_headers, self.data
-
-    def __call__(self, request, response):
-        rv = self.handler(request, response)
-        return rv
-
-
 class TestEnvironment(object):
     def __init__(self, test_paths, ssl_env, pause_after_test, debug_info, options):
         """Context manager that owns the test environment i.e. the http and
@@ -114,7 +95,6 @@ class TestEnvironment(object):
         self.options = options if options is not None else {}
 
         self.cache_manager = multiprocessing.Manager()
-        self.routes = self.get_routes()
         self.stash = serve.stash.StashServer()
 
 
@@ -126,7 +106,7 @@ class TestEnvironment(object):
         self.config = self.load_config()
         serve.set_computed_defaults(self.config)
         self.external_config, self.servers = serve.start(self.config, self.ssl_env,
-                                                         self.routes)
+                                                         self.get_routes())
         if self.options.get("supports_debugger") and self.debug_info and self.debug_info.interactive:
             self.ignore_interrupts()
         return self
@@ -195,40 +175,25 @@ class TestEnvironment(object):
             pass
 
     def get_routes(self):
-        routes = serve.default_routes()
+        route_builder = serve.RoutesBuilder()
+
         for path, format_args, content_type, route in [
                 ("testharness_runner.html", {}, "text/html", "/testharness_runner.html"),
                 (self.options.get("testharnessreport", "testharnessreport.js"),
                  {"output": self.pause_after_test}, "text/javascript",
                  "/resources/testharnessreport.js")]:
-            handler = StaticHandler(os.path.join(here, path), format_args, content_type)
-            routes.insert(0, (b"GET", str(route), handler))
+            path = os.path.normpath(os.path.join(here, path))
+            route_builder.add_static(path, format_args, content_type, route)
 
-        for url, paths in self.test_paths.iteritems():
-            if url == "/":
+        for url_base, paths in self.test_paths.iteritems():
+            if url_base == "/":
                 continue
-
-            path = paths["tests_path"]
-            url = "/%s/" % url.strip("/")
-
-            for (method,
-                 suffix,
-                 handler_cls) in [(b"*",
-                                   b"*.py",
-                                   serve.handlers.PythonScriptHandler),
-                                  (b"GET",
-                                   "*.asis",
-                                   serve.handlers.AsIsHandler),
-                                  (b"GET",
-                                   "*",
-                                   serve.handlers.FileHandler)]:
-                route = (method, b"%s%s" % (str(url), str(suffix)), handler_cls(path, url_base=url))
-                routes.insert(-3, route)
+            route_builder.add_mount_point(url_base, paths["tests_path"])
 
         if "/" not in self.test_paths:
-            routes = routes[:-3]
+            del route_builder.mountpoint_routes["/"]
 
-        return routes
+        return route_builder.get_routes()
 
     def ensure_started(self):
         # Pause for a while to ensure that the server has a chance to start


### PR DESCRIPTION
Otherwise .py files outside / will not be resolved correctly against the file system.