### PR TITLE
Fix incorrect sorting of manifests when loading tests.

### DIFF
--- a/wptrunner/testloader.py
+++ b/wptrunner/testloader.py
@@ -496,7 +496,7 @@ class TestLoader(object):
     def iter_tests(self):
         manifest_items = []
 
-        for manifest in sorted(self.manifests.keys()):
+        for manifest in sorted(self.manifests.keys(), key=lambda x:x.url_base):
             manifest_iter = iterfilter(self.manifest_filters,
                                        manifest.itertypes(*self.test_types))
             manifest_items.extend(manifest_iter)


### PR DESCRIPTION
This previously meant that manifests may be loaded in a random order, which
isn't great when combined with chunking.