### PR TITLE
Use the correct host to enable host replacement

### DIFF
--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -38,7 +38,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     return rv
 
 def env_options():
-    return {"host": "localhost",
+    return {"host": "web-platform.test",
             "bind_hostname": "true",
             "testharnessreport": "testharnessreport-servo.js",
             "supports_debugger": True}


### PR DESCRIPTION
This allows more meaningful Servo test results outside of webdriver!