### PR TITLE
fixes a typo in the README. metadat changes to metadata.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ input to the `wptupdate` tool.
 Expectation File Format
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Metadat about tests, notably including their expected results, is
+Metadata about tests, notably including their expected results, is
 stored in a modified ini-like format that is designed to be human
 editable, but also to be machine updatable.
 


### PR DESCRIPTION
i found what i believe is a typo in the README.  i updated `Metadat` to `Metadata`.