### PR TITLE
Allow per-product configuration of properties to use in metadata conditionals.

### DIFF
--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -28,7 +28,8 @@ __wptrunner__ = {"product": "firefox",
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
                  "env_options": "env_options",
-                 "run_info_extras": "run_info_extras"}
+                 "run_info_extras": "run_info_extras",
+                 "update_properties": "update_properties"}
 
 
 def check_args(**kwargs):
@@ -73,8 +74,13 @@ def env_options():
             "certificate_domain": "web-platform.test",
             "supports_debugger": True}
 
+
 def run_info_extras(**kwargs):
     return {"e10s": kwargs["gecko_e10s"]}
+
+
+def update_properties():
+    return ["debug", "e10s", "os", "version", "processor", "bits"], {"debug", "e10s"}
 
 class FirefoxBrowser(Browser):
     used_ports = set()

--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -17,7 +17,9 @@ __wptrunner__ = {"product": "servo",
                               "reftest": "ServoRefTestExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options"}
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras",
+                 "update_properties": "update_properties"}
 
 
 def check_args(**kwargs):
@@ -47,8 +49,16 @@ def env_options():
             "supports_debugger": True}
 
 
+def run_info_extras(**kwargs):
+    return {"backend": kwargs["servo_backend"]}
+
+
+def update_properties():
+    return ["debug", "os", "version", "processor", "bits", "backend"], None
+
+
 def render_arg(render_backend):
-    return {"cpu": "--cpu"}[render_backend]
+    return {"cpu": "--cpu", "webrender": "--webrender"}[render_backend]
 
 
 class ServoBrowser(NullBrowser):

--- a/wptrunner/browsers/servodriver.py
+++ b/wptrunner/browsers/servodriver.py
@@ -23,7 +23,9 @@ __wptrunner__ = {"product": "servodriver",
                               "reftest": "ServoWebDriverRefTestExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options"}
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras",
+                 "update_properties": "update_properties"}
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test
@@ -57,6 +59,14 @@ def env_options():
             "bind_hostname": "true",
             "testharnessreport": "testharnessreport-servodriver.js",
             "supports_debugger": True}
+
+
+def run_info_extras(**kwargs):
+    return {"backend": kwargs["servo_backend"]}
+
+
+def update_properties():
+    return ["debug", "os", "version", "processor", "bits", "backend"], None
 
 
 def make_hosts_file():

--- a/wptrunner/products.py
+++ b/wptrunner/products.py
@@ -55,3 +55,18 @@ def load_product(config, product):
             browser_cls, browser_kwargs,
             executor_classes, executor_kwargs,
             env_options, run_info_extras)
+
+
+def load_product_update(config, product):
+    """Return tuple of (property_order, boolean_properties) indicating the
+    run_info properties to use when constructing the expectation data for
+    this product. None for either key indicates that the default keys
+    appropriate for distinguishing based on platform will be used."""
+
+    module = product_module(config, product)
+    data = module.__wptrunner__
+
+    update_properties = (getattr(module, data["update_properties"])()
+                         if "update_properties" in data else (None, None))
+
+    return update_properties

--- a/wptrunner/update/metadata.py
+++ b/wptrunner/update/metadata.py
@@ -4,9 +4,20 @@
 
 import os
 
-from .. import metadata
+from .. import metadata, products
 
 from base import Step, StepRunner
+
+class GetUpdatePropertyList(Step):
+    provides = ["property_order", "boolean_properties"]
+
+
+    def create(self, state):
+        property_order, boolean_properties = products.load_product_update(
+            state.config, state.product)
+        state.property_order = property_order
+        state.boolean_properties = boolean_properties
+
 
 class UpdateExpected(Step):
     """Do the metadata update on the local checkout"""
@@ -24,7 +35,9 @@ class UpdateExpected(Step):
                                                      state.run_log,
                                                      rev_old=None,
                                                      ignore_existing=state.ignore_existing,
-                                                     sync_root=sync_root)
+                                                     sync_root=sync_root,
+                                                     property_order=state.property_order,
+                                                     boolean_properties=state.boolean_properties)
 
 
 class CreateMetadataPatch(Step):
@@ -57,5 +70,6 @@ class CreateMetadataPatch(Step):
 
 class MetadataUpdateRunner(StepRunner):
     """(Sub)Runner for updating metadata"""
-    steps = [UpdateExpected,
+    steps = [GetUpdatePropertyList,
+             UpdateExpected,
              CreateMetadataPatch]

--- a/wptrunner/update/update.py
+++ b/wptrunner/update/update.py
@@ -91,6 +91,8 @@ class UpdateMetadata(Step):
             state.ignore_existing = kwargs["ignore_existing"]
             state.no_patch = kwargs["no_patch"]
             state.suite_name = kwargs["suite_name"]
+            state.product = kwargs["product"]
+            state.config = kwargs["config"]
             runner = MetadataUpdateRunner(self.logger, state)
             runner.run()
 

--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -338,12 +338,25 @@ def check_args(kwargs):
 
     return kwargs
 
+def check_args_update(kwargs):
+    set_from_config(kwargs)
 
-def create_parser_update():
+    if kwargs["product"] is None:
+        kwargs["product"] = "firefox"
+
+def create_parser_update(product_choices=None):
     from mozlog.structured import commandline
+
+    import products
+
+    if product_choices is None:
+        config_data = config.load()
+        product_choices = products.products_enabled(config_data)
 
     parser = argparse.ArgumentParser("web-platform-tests-update",
                                      description="Update script for web-platform-tests tests.")
+    parser.add_argument("--product", action="store", choices=product_choices,
+                        default=None, help="Browser for which metadata is being updated")
     parser.add_argument("--config", action="store", type=abs_path, help="Path to config file")
     parser.add_argument("--metadata", action="store", type=abs_path, dest="metadata_root",
                         help="Path to the folder containing test metadata"),
@@ -386,7 +399,7 @@ def parse_args():
 def parse_args_update():
     parser = create_parser_update()
     rv = vars(parser.parse_args())
-    set_from_config(rv)
+    check_args_update(rv)
     return rv
 
 


### PR DESCRIPTION
This allows for servo to switch on the render backend, and gecko
on the e10s state, for example