### PR TITLE
executors: trust marionette logging defaults

### DIFF
--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -107,12 +107,6 @@ class MarionetteProtocol(Protocol):
         return True
 
     def after_connect(self):
-        # Turn off debug-level logging by default since this is so verbose
-        with self.marionette.using_context("chrome"):
-            self.marionette.execute_script("""
-              Components.utils.import("resource://gre/modules/Log.jsm");
-              Log.repository.getLogger("Marionette").level = Log.Level.Info;
-            """)
         self.load_runner("http")
 
     def load_runner(self, protocol):


### PR DESCRIPTION
Following https://bugzil.la/1221187 Marionette uses sensible logging
defaults.  Full trace logging is only available through setting the
marionette.logging preference to "TRACE".