### PR TITLE
Increase init timeout since debug builds can be quite slow to start

### DIFF
--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -82,6 +82,7 @@ def update_properties():
 
 class FirefoxBrowser(Browser):
     used_ports = set()
+    init_timeout = 60
 
     def __init__(self, logger, binary, prefs_root, debug_info=None,
                  symbols_path=None, stackwalk_binary=None, certutil_binary=None,


### PR DESCRIPTION
at least on my laptop.

A perfectionist might look for a better solution than a timeout here, but it's not
clear to me what that better solution is.