### PR TITLE
Added --binary-arg option, which passes an argument to the browser binary.

### DIFF
--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -29,6 +29,7 @@ def check_args(**kwargs):
 def browser_kwargs(**kwargs):
     return {"binary": kwargs["binary"],
             "debug_info": kwargs["debug_info"],
+            "binary_args": kwargs["binary_args"],
             "user_stylesheets": kwargs.get("user_stylesheets"),
             "render_backend": kwargs.get("servo_backend")}
 
@@ -58,20 +59,22 @@ def update_properties():
 
 
 def render_arg(render_backend):
-    return {"cpu": "--cpu", "webrender": "--webrender"}[render_backend]
+    return {"cpu": "--cpu", "webrender": "-w"}[render_backend]
 
 
 class ServoBrowser(NullBrowser):
-    def __init__(self, logger, binary, debug_info=None, user_stylesheets=None,
-                 render_backend="cpu"):
+    def __init__(self, logger, binary, debug_info=None, binary_args=None,
+                 user_stylesheets=None, render_backend="cpu"):
         NullBrowser.__init__(self, logger)
         self.binary = binary
         self.debug_info = debug_info
+        self.binary_args = binary_args or []
         self.user_stylesheets = user_stylesheets or []
         self.render_backend = render_backend
 
     def executor_browser(self):
         return ExecutorBrowser, {"binary": self.binary,
                                  "debug_info": self.debug_info,
+                                 "binary_args": self.binary_args,
                                  "user_stylesheets": self.user_stylesheets,
                                  "render_backend": self.render_backend}

--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -76,6 +76,7 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
             args += ["--user-stylesheet", stylesheet]
         for pref in test.environment.get('prefs', {}):
             args += ["--pref", pref]
+        args += self.browser.binary_args
         debug_args, command = browser_command(self.binary, args, self.debug_info)
 
         self.command = command

--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -58,6 +58,9 @@ def create_parser(product_choices=None):
 
     parser.add_argument("--binary", action="store",
                         type=abs_path, help="Binary to run tests against")
+    parser.add_argument('--binary-arg',
+                        default=[], action="append", dest="binary_args",
+                        help="Extra argument for the binary (servo)")
     parser.add_argument("--webdriver-binary", action="store", metavar="BINARY",
                         type=abs_path, help="WebDriver server binary to use")
     parser.add_argument("--processes", action="store", type=int, default=None,
@@ -127,9 +130,6 @@ def create_parser(product_choices=None):
                                  help="Path or url to symbols file used to analyse crash minidumps.")
     debugging_group.add_argument("--stackwalk-binary", action="store", type=abs_path,
                                  help="Path to stackwalker program used to analyse minidumps.")
-
-    debugging_group.add_argument("--pdb", action="store_true",
-                                 help="Drop into pdb on python exception")
 
     chunking_group = parser.add_argument_group("Test Chunking")
     chunking_group.add_argument("--total-chunks", action="store", type=int, default=1,


### PR DESCRIPTION
Added a `--servo-arg` command line option, and a matching `servo_args` parameter to `ServoBrowser`. This passes arbitrary command line arguments to Servo.