### PR TITLE
webdriver_server: support checking alive state of unstarted process

### DIFF
--- a/wptrunner/webdriver_server.py
+++ b/wptrunner/webdriver_server.py
@@ -87,9 +87,7 @@ class WebDriverServer(object):
 
     @property
     def is_alive(self):
-        return (self._proc is not None and
-                self._proc.proc is not None and
-                self._proc.poll() is None)
+        return hasattr(self._proc, "proc") and self._proc.poll() is None
 
     def on_output(self, line):
         self.logger.process_output(self.pid,


### PR DESCRIPTION
mozprocess.Process._proc.proc is not defined before the process is
started.  Instead of checking if it is None, we check if the attribute
is defined.