### PR TITLE
Always pass a resolution to Servo reftests.

### DIFF
--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -224,8 +224,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
             for pref in test.environment.get('prefs', {}):
                 command += ["--pref", pref]
 
-            if viewport_size:
-                command += ["--resolution", viewport_size]
+            command += ["--resolution", viewport_size or "800x600"]
 
             if dpi:
                 command += ["--device-pixel-ratio", dpi]


### PR DESCRIPTION
This makes wptrunner more robust to changes to the default value.