### PR TITLE
Use actual console output, rather than alert dialogs

### DIFF
--- a/wptrunner/testharnessreport-servo.js
+++ b/wptrunner/testharnessreport-servo.js
@@ -8,7 +8,7 @@ setup(props);
 
 add_completion_callback(function (tests, harness_status) {
     var id = location.pathname + location.search + location.hash;
-    console.log("RESULT: " + JSON.stringify([
+    console.log("ALERT RESULT: " + JSON.stringify([
         id,
         harness_status.status,
         harness_status.message,

--- a/wptrunner/testharnessreport-servo.js
+++ b/wptrunner/testharnessreport-servo.js
@@ -8,7 +8,7 @@ setup(props);
 
 add_completion_callback(function (tests, harness_status) {
     var id = location.pathname + location.search + location.hash;
-    alert("RESULT: " + JSON.stringify([
+    console.log("RESULT: " + JSON.stringify([
         id,
         harness_status.status,
         harness_status.message,


### PR DESCRIPTION
Now that Servo has actual alert dialogs, long logging strings can cause problems.