### PR TITLE
Delay wdspec imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 html5lib >= 0.99
 mozinfo >= 0.7
-mozlog >= 3.0
+mozlog >= 3.3
 mozdebug >= 0.1

--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -17,11 +17,11 @@ from ..wpttest import WdspecResult, WdspecSubtestResult
 
 errors = None
 marionette = None
+pytestrunner = None
 webdriver = None
 
 here = os.path.join(os.path.split(__file__)[0])
 
-from . import pytestrunner
 from .base import (ExecutorException,
                    Protocol,
                    RefTestExecutor,
@@ -41,7 +41,7 @@ extra_timeout = 5 # seconds
 
 
 def do_delayed_imports():
-    global errors, marionette, webdriver
+    global errors, marionette
 
     # Marionette client used to be called marionette, recently it changed
     # to marionette_driver for unfathomable reasons
@@ -50,8 +50,6 @@ def do_delayed_imports():
         from marionette import errors
     except ImportError:
         from marionette_driver import marionette, errors
-
-    import webdriver
 
 
 class MarionetteProtocol(Protocol):
@@ -526,6 +524,7 @@ class WdspecRun(object):
 class MarionetteWdspecExecutor(WdspecExecutor):
     def __init__(self, browser, server_config, webdriver_binary,
                  timeout_multiplier=1, close_after_done=True, debug_info=None):
+        self.do_delayed_imports()
         WdspecExecutor.__init__(self, browser, server_config,
                                 timeout_multiplier=timeout_multiplier,
                                 debug_info=debug_info)
@@ -555,3 +554,8 @@ class MarionetteWdspecExecutor(WdspecExecutor):
         harness_result = ("OK", None)
         subtest_results = pytestrunner.run(path, session, timeout=timeout)
         return (harness_result, subtest_results)
+
+    def do_delayed_imports(self):
+        global pytestrunner, webdriver
+        from . import pytestrunner
+        from tools import webdriver

--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -28,16 +28,16 @@ from ..browsers.base import browser_command
 from ..wpttest import WdspecResult, WdspecSubtestResult
 from ..webdriver_server import ServoDriverServer
 from .executormarionette import WdspecRun
-from . import pytestrunner
 
+pytestrunner = None
 render_arg = None
 webdriver = None
+
 extra_timeout = 5 # seconds
 
 def do_delayed_imports():
-    global render_arg, webdriver
+    global render_arg
     from ..browsers.servo import render_arg
-    import webdriver
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test
@@ -285,7 +285,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
 
 class ServoWdspecProtocol(Protocol):
     def __init__(self, executor, browser):
-        do_delayed_imports()
+        self.do_delayed_imports()
         Protocol.__init__(self, executor, browser)
         self.session = None
         self.server = None
@@ -323,6 +323,12 @@ class ServoWdspecProtocol(Protocol):
         conn.request("HEAD", self.server.base_path + "invalid")
         res = conn.getresponse()
         return res.status == 404
+
+    def do_delayed_imports(self):
+        global pytestrunner, webdriver
+        from . import pytestrunner
+        from tools import webdriver
+
 
 class ServoWdspecExecutor(WdspecExecutor):
     def __init__(self, browser, server_config,

--- a/wptrunner/executors/executorservodriver.py
+++ b/wptrunner/executors/executorservodriver.py
@@ -14,7 +14,6 @@ from .base import (Protocol,
                    RefTestImplementation,
                    TestharnessExecutor,
                    strip_server)
-from .. import webdriver
 from ..testrunner import Stop
 
 webdriver = None
@@ -26,7 +25,7 @@ extra_timeout = 5
 
 def do_delayed_imports():
     global webdriver
-    import webdriver
+    from tools import webdriver
 
 
 class ServoWebDriverProtocol(Protocol):

--- a/wptrunner/executors/pytestrunner/fixtures.py
+++ b/wptrunner/executors/pytestrunner/fixtures.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pytest
-import webdriver
+from tools import pytest
+from tools import webdriver
 
 
 """pytest fixtures for use in Python-based WPT tests.


### PR DESCRIPTION
Makes pytestrunner-specific imports lazily loaded only when you need pytestrunner. See the commit message for a full explanation.