### PR TITLE
Fix Firefox harness with HTTP proxy

### DIFF
--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -130,6 +130,7 @@ class FirefoxBrowser(Browser):
                                       "marionette.defaultPrefs.port": self.marionette_port,
                                       "dom.disable_open_during_load": False,
                                       "network.dns.localDomains": ",".join(hostnames),
+                                      "network.proxy.type": 0,
                                       "places.history.enabled": False})
         if self.e10s:
             self.profile.set_preferences({"browser.tabs.remote.autostart": True})


### PR DESCRIPTION
./mach web-platform-tests tries to access the tests at
http://web-platform.test/.  If an HTTP proxy is configured, it tries to
access it via the proxy, which fails.  Disabling the proxy entirely
fixes the problem and should probably have no adverse effects, although
a cleaner solution would be to skip proxies only for that domain (as is
done with localhost).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/199)
<!-- Reviewable:end -->
