### PR TITLE
Introduce http fixture from WPT

### DIFF
--- a/wptrunner/executors/pytestrunner/runner.py
+++ b/wptrunner/executors/pytestrunner/runner.py
@@ -45,6 +45,7 @@ def run(path, session, timeout=0):
 
     recorder = SubtestResultRecorder()
     plugins = [recorder,
+               fixtures,
                fixtures.Session(session)]
 
     # TODO(ato): Deal with timeouts


### PR DESCRIPTION
This fixture for making HTTP requests to the WebDriver remote end server
has already been reviewed in WPT, and this change moves it to wptrunner
so it can be accessed by all wdspec tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/211)
<!-- Reviewable:end -->
