### PR TITLE
Keep the original URL in servo test report

### DIFF
--- a/wptrunner/testharnessreport-servo.js
+++ b/wptrunner/testharnessreport-servo.js
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var props = {output:%(output)d};
-
+var start_loc = document.createElement('a');
+start_loc.href = location.href;
 setup(props);
 
 add_completion_callback(function (tests, harness_status) {
-    var id = location.pathname + location.search + location.hash;
+    var id = start_loc.pathname + start_loc.search + start_loc.hash;
     console.log("ALERT: RESULT: " + JSON.stringify([
         id,
         harness_status.status,


### PR DESCRIPTION
Currently wpt runner will compare the start url and the result url in tests, while the in servo there are some tests like `location_replace.html` will change the url fragment and not restore it. This patch tries to store the starting location and send it back when reporting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/214)
<!-- Reviewable:end -->
