### PR TITLE
servo: Check `reftest-wait` in the document element

### DIFF
--- a/test/testdata/reftest/reftest_wait_0.html
+++ b/test/testdata/reftest/reftest_wait_0.html
@@ -1,11 +1,13 @@
+<html class="reftest-wait">
 <title>rel=match that should fail</title>
 <link rel=match href=red.html>
 <style>
 :root {background-color:red}
 </style>
-<body class="reftest-wait">
 <script>
 setTimeout(function() {
   document.documentElement.style.backgroundColor = "green";
-  body.className = "";
+  document.documentElement.className = "";
 }, 2000);
+</script>
+</html>

--- a/wptrunner/executors/reftest-wait_servodriver.js
+++ b/wptrunner/executors/reftest-wait_servodriver.js
@@ -6,7 +6,7 @@
 callback = arguments[arguments.length - 1];
 
 function check_done() {
-    if (!document.body.classList.contains('reftest-wait')) {
+    if (!document.documentElement.classList.contains('reftest-wait')) {
         callback();
     } else {
         setTimeout(check_done, 50);


### PR DESCRIPTION
Turns out that the reftest-wait functionality in Servo's test is being used in
the document element instead of the body, which we suspect is causing a lot of
intermittent test failures.

r? @jgraham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/219)
<!-- Reviewable:end -->
