### PR TITLE
Error on missing webdriver_binary

### DIFF
--- a/wptrunner/webdriver_server.py
+++ b/wptrunner/webdriver_server.py
@@ -28,6 +28,10 @@ class WebDriverServer(object):
 
     def __init__(self, logger, binary, host="127.0.0.1", port=None,
                  base_path="", env=None):
+        if binary is None:
+            raise ValueError("WebDriver server binary must be given "
+                             "to --webdriver-binary argument")
+
         self.logger = logger
         self.binary = binary
         self.host = host


### PR DESCRIPTION
If `None` is passed to the `webdriver_binary` ctor argument cryptic
`'NoneType' object has no attribute 'rfind'` exceptions are thrown
by subprocess.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/220)
<!-- Reviewable:end -->
