### PR TITLE
Change default geckodriver binary

### DIFF
--- a/wptrunner/webdriver_server.py
+++ b/wptrunner/webdriver_server.py
@@ -153,7 +153,7 @@ class EdgeDriverServer(WebDriverServer):
 
 
 class GeckoDriverServer(WebDriverServer):
-    def __init__(self, logger, marionette_port=2828, binary="wires",
+    def __init__(self, logger, marionette_port=2828, binary="geckodriver",
                  host="127.0.0.1", port=None):
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"


### PR DESCRIPTION
geckodriver used to be called wires, but it is now called geckodriver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/221)
<!-- Reviewable:end -->
