### PR TITLE
Ensure marionette screenshots cover the viewport.

### DIFF
--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -508,7 +508,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
 
         marionette.execute_async_script(self.wait_script)
 
-        screenshot = marionette.screenshot()
+        screenshot = marionette.screenshot(full=False)
         # strip off the data:img/png, part of the url
         if screenshot.startswith("data:image/png;base64,"):
             screenshot = screenshot.split(",", 1)[1]


### PR DESCRIPTION
It turns out the default marionette screenshot mode will attempt to screenshot
the html element, including cropping below the viewport size. This isn't expected
behaviour for reftests, so disable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/223)
<!-- Reviewable:end -->
