### PR TITLE
Remove obsolete flags for Servo rendering backends

### DIFF
--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -28,11 +28,12 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(**kwargs):
-    return {"binary": kwargs["binary"],
-            "debug_info": kwargs["debug_info"],
-            "binary_args": kwargs["binary_args"],
-            "user_stylesheets": kwargs.get("user_stylesheets"),
-            "render_backend": kwargs.get("servo_backend")}
+    return {
+        "binary": kwargs["binary"],
+        "debug_info": kwargs["debug_info"],
+        "binary_args": kwargs["binary_args"],
+        "user_stylesheets": kwargs.get("user_stylesheets"),
+    }
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
@@ -51,31 +52,23 @@ def env_options():
             "supports_debugger": True}
 
 
-def run_info_extras(**kwargs):
-    return {"backend": kwargs["servo_backend"]}
-
-
 def update_properties():
-    return ["debug", "os", "version", "processor", "bits", "backend"], None
-
-
-def render_arg(render_backend):
-    return {"cpu": "--cpu", "webrender": "-w"}[render_backend]
+    return ["debug", "os", "version", "processor", "bits"], None
 
 
 class ServoBrowser(NullBrowser):
     def __init__(self, logger, binary, debug_info=None, binary_args=None,
-                 user_stylesheets=None, render_backend="webrender"):
+                 user_stylesheets=None):
         NullBrowser.__init__(self, logger)
         self.binary = binary
         self.debug_info = debug_info
         self.binary_args = binary_args or []
         self.user_stylesheets = user_stylesheets or []
-        self.render_backend = render_backend
 
     def executor_browser(self):
-        return ExecutorBrowser, {"binary": self.binary,
-                                 "debug_info": self.debug_info,
-                                 "binary_args": self.binary_args,
-                                 "user_stylesheets": self.user_stylesheets,
-                                 "render_backend": self.render_backend}
+        return ExecutorBrowser, {
+            "binary": self.binary,
+            "debug_info": self.debug_info,
+            "binary_args": self.binary_args,
+            "user_stylesheets": self.user_stylesheets,
+        }

--- a/wptrunner/executors/executorservo.py
+++ b/wptrunner/executors/executorservo.py
@@ -30,14 +30,9 @@ from ..webdriver_server import ServoDriverServer
 from .executormarionette import WdspecRun
 
 pytestrunner = None
-render_arg = None
 webdriver = None
 
 extra_timeout = 5 # seconds
-
-def do_delayed_imports():
-    global render_arg
-    from ..browsers.servo import render_arg
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test
@@ -80,8 +75,10 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
         self.result_data = None
         self.result_flag = threading.Event()
 
-        args = [render_arg(self.browser.render_backend), "--hard-fail", "-u", "Servo/wptrunner",
-                "-Z", "replace-surrogates", "-z", self.test_url(test)]
+        args = [
+            "--hard-fail", "-u", "Servo/wptrunner",
+            "-Z", "replace-surrogates", "-z", self.test_url(test),
+        ]
         for stylesheet in self.browser.user_stylesheets:
             args += ["--user-stylesheet", stylesheet]
         for pref, value in test.environment.get('prefs', {}).iteritems():
@@ -213,9 +210,12 @@ class ServoRefTestExecutor(ProcessTestExecutor):
         with TempFilename(self.tempdir) as output_path:
             debug_args, command = browser_command(
                 self.binary,
-                [render_arg(self.browser.render_backend), "--hard-fail", "--exit",
-                 "-u", "Servo/wptrunner", "-Z", "disable-text-aa,load-webfonts-synchronously,replace-surrogates",
-                 "--output=%s" % output_path, full_url] + self.browser.binary_args,
+                [
+                    "--hard-fail", "--exit",
+                    "-u", "Servo/wptrunner",
+                    "-Z", "disable-text-aa,load-webfonts-synchronously,replace-surrogates",
+                    "--output=%s" % output_path, full_url
+                ] + self.browser.binary_args,
                 self.debug_info)
 
             for stylesheet in self.browser.user_stylesheets:
@@ -295,7 +295,7 @@ class ServoWdspecProtocol(Protocol):
 
     def setup(self, runner):
         try:
-            self.server = ServoDriverServer(self.logger, binary=self.browser.binary, binary_args=self.browser.binary_args, render_backend=self.browser.render_backend)
+            self.server = ServoDriverServer(self.logger, binary=self.browser.binary, binary_args=self.browser.binary_args)
             self.server.start(block=False)
             self.logger.info(
                 "WebDriver HTTP server listening at %s" % self.server.url)

--- a/wptrunner/webdriver_server.py
+++ b/wptrunner/webdriver_server.py
@@ -169,12 +169,11 @@ class GeckoDriverServer(WebDriverServer):
 
 
 class ServoDriverServer(WebDriverServer):
-    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1", port=None, render_backend=None):
+    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1", port=None):
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"
         WebDriverServer.__init__(self, logger, binary, host=host, port=port, env=env)
         self.binary_args = binary_args
-        self.render_backend = render_backend
 
     def make_command(self):
         command = [self.binary,
@@ -183,10 +182,6 @@ class ServoDriverServer(WebDriverServer):
                    "--headless"]
         if self.binary_args:
             command += self.binary_args
-        if self.render_backend == "cpu":
-            command += ["--cpu"]
-        elif self.render_backend == "webrender":
-            command += ["--webrender"]
         return command
 
 

--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -180,9 +180,6 @@ scheme host and port.""")
     servo_group.add_argument("--user-stylesheet",
                              default=[], action="append", dest="user_stylesheets",
                              help="Inject a user CSS stylesheet into every test.")
-    servo_group.add_argument("--servo-backend",
-                             default="webrender", choices=["cpu", "webrender"],
-                             help="Rendering backend to use with Servo.")
 
 
     parser.add_argument("test_list", nargs="*",


### PR DESCRIPTION
The `--cpu` and `-w` flags are obsolete because WebRender is always used.
Needed for https://github.com/servo/servo/pull/15064.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/224)
<!-- Reviewable:end -->
