### PR TITLE
Fixup for removing old flags for Servo backends

### DIFF
--- a/wptrunner/browsers/servo.py
+++ b/wptrunner/browsers/servo.py
@@ -10,17 +10,20 @@ from ..executors.executorservo import ServoTestharnessExecutor, ServoRefTestExec
 
 here = os.path.join(os.path.split(__file__)[0])
 
-__wptrunner__ = {"product": "servo",
-                 "check_args": "check_args",
-                 "browser": "ServoBrowser",
-                 "executor": {"testharness": "ServoTestharnessExecutor",
-                              "reftest": "ServoRefTestExecutor",
-                              "wdspec": "ServoWdspecExecutor"},
-                 "browser_kwargs": "browser_kwargs",
-                 "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options",
-                 "run_info_extras": "run_info_extras",
-                 "update_properties": "update_properties"}
+__wptrunner__ = {
+    "product": "servo",
+    "check_args": "check_args",
+    "browser": "ServoBrowser",
+    "executor": {
+        "testharness": "ServoTestharnessExecutor",
+        "reftest": "ServoRefTestExecutor",
+        "wdspec": "ServoWdspecExecutor",
+    },
+    "browser_kwargs": "browser_kwargs",
+    "executor_kwargs": "executor_kwargs",
+    "env_options": "env_options",
+    "update_properties": "update_properties",
+}
 
 
 def check_args(**kwargs):

--- a/wptrunner/browsers/servodriver.py
+++ b/wptrunner/browsers/servodriver.py
@@ -15,16 +15,19 @@ from ..executors.executorservodriver import (ServoWebDriverTestharnessExecutor,
 
 here = os.path.join(os.path.split(__file__)[0])
 
-__wptrunner__ = {"product": "servodriver",
-                 "check_args": "check_args",
-                 "browser": "ServoWebDriverBrowser",
-                 "executor": {"testharness": "ServoWebDriverTestharnessExecutor",
-                              "reftest": "ServoWebDriverRefTestExecutor"},
-                 "browser_kwargs": "browser_kwargs",
-                 "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options",
-                 "run_info_extras": "run_info_extras",
-                 "update_properties": "update_properties"}
+__wptrunner__ = {
+    "product": "servodriver",
+    "check_args": "check_args",
+    "browser": "ServoWebDriverBrowser",
+    "executor": {
+        "testharness": "ServoWebDriverTestharnessExecutor",
+        "reftest": "ServoWebDriverRefTestExecutor",
+    },
+    "browser_kwargs": "browser_kwargs",
+    "executor_kwargs": "executor_kwargs",
+    "env_options": "env_options",
+    "update_properties": "update_properties",
+}
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test


### PR DESCRIPTION
These references to `run_info_extras` were missed in the first commit.

Follow-up to #224; cc @Ms2ger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/226)
<!-- Reviewable:end -->
