### PR TITLE
Added command line options to set the host and external_host.

### DIFF
--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -131,6 +131,10 @@ scheme host and port.""")
                               help="Path to directory containing extra json files to add to run info")
     config_group.add_argument("--product", action="store", choices=product_choices,
                               default=None, help="Browser against which to run tests")
+    config_group.add_argument("--host", action="store", dest="host",
+                              help="The server host")
+    config_group.add_argument("--external-host", action="store", dest="external_host",
+                              help="The server host name")
     config_group.add_argument("--config", action="store", type=abs_path, dest="config",
                               help="Path to config file")
 

--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -148,8 +148,8 @@ def run_tests(config, test_paths, product, **kwargs):
 
         kwargs["pause_after_test"] = get_pause_after_test(test_loader, **kwargs)
 
-        env_options["host"] = kwargs.get("host") or env_options["host"]
-        env_options["external_host"] = kwargs.get("external_host") or env_options["external_host"]
+        env_options["host"] = kwargs.get("host", env_options["host"])
+        env_options["external_host"] = kwargs.get("external_host", env_options["external_host"])
 
         with env.TestEnvironment(test_paths,
                                  ssl_env,

--- a/wptrunner/wptrunner.py
+++ b/wptrunner/wptrunner.py
@@ -148,6 +148,9 @@ def run_tests(config, test_paths, product, **kwargs):
 
         kwargs["pause_after_test"] = get_pause_after_test(test_loader, **kwargs)
 
+        env_options["host"] = kwargs.get("host") or env_options["host"]
+        env_options["external_host"] = kwargs.get("external_host") or env_options["external_host"]
+
         with env.TestEnvironment(test_paths,
                                  ssl_env,
                                  kwargs["pause_after_test"],


### PR DESCRIPTION
In the Servo CI, it would be nice to run the wpt tests with `external_host` set to `localhost`, since that exposes some corner cases (in particular, some cases where fetch is not throwing security errors).

At the moment, setting `host` and `external_host` requires editing `wptrunner/browsers/servo.py`. This PR allows them to be set from the command line.

The Servo issue is https://github.com/servo/servo/issues/15232.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/231)
<!-- Reviewable:end -->
