### PR TITLE
Support --binary-arg for Chome and Firefox

### DIFF
--- a/wptrunner/browsers/chrome.py
+++ b/wptrunner/browsers/chrome.py
@@ -43,8 +43,9 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
             }
         }
     }
-    if kwargs["binary"] is not None:
-        capabilities["chromeOptions"]["binary"] = kwargs["binary"]
+    for (kwarg, capability) in [("binary", "binary"), ("binary_args", "args")]:
+        if kwargs[kwarg] is not None:
+            capabilities["chromeOptions"][capability] = kwargs[kwarg]
     executor_kwargs["capabilities"] = capabilities
     return executor_kwargs
 

--- a/wptrunner/executors/pytestrunner/runner.py
+++ b/wptrunner/executors/pytestrunner/runner.py
@@ -13,6 +13,7 @@ Usage::
 """
 
 import errno
+import json
 import os
 import shutil
 import tempfile
@@ -28,13 +29,13 @@ def do_delayed_imports():
     import pytest
 
 
-def run(path, session, timeout=0):
+def run(path, session_config, timeout=0):
     """Run Python test at ``path`` in pytest.  The provided ``session``
     is exposed as a fixture available in the scope of the test functions.
 
     :param path: Path to the test file.
-    :param session: wdclient instance containing HTTP connection parameters to
-        a running WebDriver remote end.
+    :param session_config: dictionary of host, port,capabilities parameters
+    to pass through to the webdriver session
     :param timeout: Duration before interrupting potentially hanging
         tests.  If 0, there is no timeout.
 
@@ -47,8 +48,9 @@ def run(path, session, timeout=0):
 
     recorder = SubtestResultRecorder()
 
-    os.environ["WD_HOST"] = session.transport.host
-    os.environ["WD_PORT"] = str(session.transport.port)
+    os.environ["WD_HOST"] = session_config["host"]
+    os.environ["WD_PORT"] = str(session_config["port"])
+    os.environ["WD_CAPABILITIES"] = json.dumps(session_config["capabilities"])
 
     plugins = [recorder]
 

--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -119,7 +119,7 @@ scheme host and port.""")
                               type=abs_path, help="Binary to run tests against")
     config_group.add_argument('--binary-arg',
                               default=[], action="append", dest="binary_args",
-                              help="Extra argument for the binary (servo)")
+                              help="Extra argument for the binary")
     config_group.add_argument("--webdriver-binary", action="store", metavar="BINARY",
                               type=abs_path, help="WebDriver server binary to use")
 


### PR DESCRIPTION
To allow this with WebDriver tests some bugfixing around the way that
arguments are passed in to the session was required, so this also
ensures that WebDriver tests honour the binary argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/235)
<!-- Reviewable:end -->
