### PR TITLE
Allow passing extra options to WebDriver server.

### DIFF
--- a/wptrunner/browsers/chrome.py
+++ b/wptrunner/browsers/chrome.py
@@ -25,7 +25,8 @@ def check_args(**kwargs):
 
 def browser_kwargs(**kwargs):
     return {"binary": kwargs["binary"],
-            "webdriver_binary": kwargs["webdriver_binary"]}
+            "webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": kwargs.get("webdriver_args")}
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
@@ -60,12 +61,15 @@ class ChromeBrowser(Browser):
     ``wptrunner.webdriver.ChromeDriverServer``.
     """
 
-    def __init__(self, logger, binary, webdriver_binary="chromedriver"):
+    def __init__(self, logger, binary, webdriver_binary="chromedriver",
+                 webdriver_args=None):
         """Creates a new representation of Chrome.  The `binary` argument gives
         the browser binary to use for testing."""
         Browser.__init__(self, logger)
         self.binary = binary
-        self.server = ChromeDriverServer(self.logger, binary=webdriver_binary)
+        self.server = ChromeDriverServer(self.logger,
+                                         binary=webdriver_binary,
+                                         args=webdriver_args)
 
     def start(self):
         self.server.start(block=False)

--- a/wptrunner/browsers/edge.py
+++ b/wptrunner/browsers/edge.py
@@ -22,7 +22,8 @@ def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
 def browser_kwargs(**kwargs):
-    return {"webdriver_binary": kwargs["webdriver_binary"]}
+    return {"webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": kwargs.get("webdriver_args")}
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
                     **kwargs):
@@ -42,9 +43,11 @@ def env_options():
 class EdgeBrowser(Browser):
     used_ports = set()
 
-    def __init__(self, logger, webdriver_binary):
+    def __init__(self, logger, webdriver_binary, webdriver_args=None):
         Browser.__init__(self, logger)
-        self.server = EdgeDriverServer(self.logger, binary=webdriver_binary)
+        self.server = EdgeDriverServer(self.logger,
+                                       binary=webdriver_binary,
+                                       args=webdriver_args)
         self.webdriver_host = "localhost"
         self.webdriver_port = self.server.port
 

--- a/wptrunner/browsers/firefox.py
+++ b/wptrunner/browsers/firefox.py
@@ -76,7 +76,9 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         elif run_info_data["debug"] or run_info_data.get("asan"):
             executor_kwargs["timeout_multiplier"] = 3
     if test_type == "wdspec":
+        executor_kwargs["binary"] = kwargs["binary"]
         executor_kwargs["webdriver_binary"] = kwargs.get("webdriver_binary")
+        executor_kwargs["webdriver_args"] = kwargs.get("webdriver_args")
         fxOptions = {}
         if kwargs["binary"]:
             fxOptions["binary"] = kwargs["binary"]

--- a/wptrunner/executors/executormarionette.py
+++ b/wptrunner/executors/executormarionette.py
@@ -270,6 +270,7 @@ class RemoteMarionetteProtocol(Protocol):
         do_delayed_imports()
         Protocol.__init__(self, executor, browser)
         self.webdriver_binary = executor.webdriver_binary
+        self.webdriver_args = executor.webdriver_args
         self.capabilities = self.executor.capabilities
         self.session_config = None
         self.server = None
@@ -278,7 +279,9 @@ class RemoteMarionetteProtocol(Protocol):
         """Connect to browser via the Marionette HTTP server."""
         try:
             self.server = GeckoDriverServer(
-                self.logger, binary=self.webdriver_binary)
+                self.logger,
+                binary=self.webdriver_binary,
+                args=self.webdriver_args)
             self.server.start(block=False)
             self.logger.info(
                 "WebDriver HTTP server listening at %s" % self.server.url)
@@ -553,12 +556,13 @@ class WdspecRun(object):
 class MarionetteWdspecExecutor(WdspecExecutor):
     def __init__(self, browser, server_config, webdriver_binary,
                  timeout_multiplier=1, close_after_done=True, debug_info=None,
-                 capabilities=None):
+                 capabilities=None, webdriver_args=None, binary=None):
         self.do_delayed_imports()
         WdspecExecutor.__init__(self, browser, server_config,
                                 timeout_multiplier=timeout_multiplier,
                                 debug_info=debug_info)
         self.webdriver_binary = webdriver_binary
+        self.webdriver_args = webdriver_args + ["--binary", binary]
         self.capabilities = capabilities
         self.protocol = RemoteMarionetteProtocol(self, browser)
 

--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -122,6 +122,9 @@ scheme host and port.""")
                               help="Extra argument for the binary")
     config_group.add_argument("--webdriver-binary", action="store", metavar="BINARY",
                               type=abs_path, help="WebDriver server binary to use")
+    config_group.add_argument('--webdriver-arg',
+                              default=[], action="append", dest="webdriver_args",
+                              help="Extra argument for the WebDriver binary")
 
     config_group.add_argument("--metadata", action="store", type=abs_path, dest="metadata_root",
                               help="Path to root directory containing test metadata"),


### PR DESCRIPTION
Add a --webdriver-arg that passes extra options to the webdriver
server binary. Depending on the implementation this may allow setting
e.g. the browser binary and the logging level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/238)
<!-- Reviewable:end -->
