### PR TITLE
fix NameError in chrome browser file

### DIFF
--- a/wptrunner/browsers/chrome.py
+++ b/wptrunner/browsers/chrome.py
@@ -75,7 +75,7 @@ class ChromeBrowser(Browser):
         self.server.start(block=False)
 
     def stop(self, force=False):
-        self.server.stop(force=Force)
+        self.server.stop(force=force)
 
     def pid(self):
         return self.server.pid


### PR DESCRIPTION
Fixes `NameError` introduced in 5b60647a41dacd9f1f32993b8dae935fc9c98329

- See: https://travis-ci.org/w3c/web-platform-tests/jobs/216311915
- See: https://github.com/w3c/web-platform-tests/pull/5251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/251)
<!-- Reviewable:end -->
