### PR TITLE
conditionally download sauce connect and start automatically

### DIFF
--- a/wptrunner/wptcommandline.py
+++ b/wptrunner/wptcommandline.py
@@ -201,6 +201,9 @@ scheme host and port.""")
     sauce_group.add_argument("--sauce-key", dest="sauce_key",
                              default=os.environ.get("SAUCE_ACCESS_KEY"),
                              help="Sauce Labs access key")
+    sauce_group.add_argument("--sauce-connect-binary",
+                             dest="sauce_connect_binary",
+                             help="Path to Sauce Connect binary")
 
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "


### PR DESCRIPTION
This autostarts sauce connect when running tests on Sauce Labs. If a path to the sauce connect binary is passed in as an argument, that is used, otherwise, it downloads and runs the latest sauce connect binary.

Note: Full Sauce support requires https://github.com/w3c/wptrunner/pull/246 be merged as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptrunner/253)
<!-- Reviewable:end -->
